### PR TITLE
Added year properties to quizzes

### DIFF
--- a/src/interfaces/IQuestion.ts
+++ b/src/interfaces/IQuestion.ts
@@ -13,6 +13,7 @@ interface IQuestion extends Document {
   author: Types.ObjectId;
   isModerated: boolean;
   moderatedBy: Types.ObjectId;
+  year: number;
 }
 
 export default IQuestion;

--- a/src/models/question.model.ts
+++ b/src/models/question.model.ts
@@ -47,6 +47,10 @@ const QuestionSchema = new Schema<IQuestion>(
       type: Schema.Types.ObjectId,
       ref: "User",
     },
+    year: {
+      type: Number,
+      default: new Date().getFullYear(),
+    },
   },
   {
     timestamps: true,


### PR DESCRIPTION
This pull request introduces a new `year` field to the `Question` model to track the year associated with each question. The field is added to both the interface and the schema, and is set to default to the current year.

Model and interface updates:

* Added a `year: number` property to the `IQuestion` interface in `src/interfaces/IQuestion.ts` to represent the year of the question.
* Added a `year` field to the `QuestionSchema` in `src/models/question.model.ts`, with a default value set to the current year.