### PR TITLE
Added free quiz credits on sign in

### DIFF
--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -57,7 +57,7 @@ const UserSchema = new Schema<IUser>(
     },
     quizCredits: {
       type: Number,
-      default: 0,
+      default: 1200,
     },
     paymentId: {
       type: [Schema.Types.ObjectId],


### PR DESCRIPTION
This pull request updates the default value for the `quizCredits` field in the `UserSchema`. New users will now start with a higher initial quiz credit balance.

* Increased the default value for `quizCredits` from 0 to 1200 in `src/models/user.model.ts` (`UserSchema`).